### PR TITLE
Increase sleep time before Edge Deployment

### DIFF
--- a/instruqt-tracks/prosimo-lab-observe-and-troubleshoot/track_scripts/setup-shell
+++ b/instruqt-tracks/prosimo-lab-observe-and-troubleshoot/track_scripts/setup-shell
@@ -18,7 +18,7 @@ cp -r /root/ProsimoLabs/instruqt-tracks/prosimo-lab-observe-and-troubleshoot/ass
 # Run Python scripts
 cd /root/prosimo-lab/
 python3 assets/scripts/tenant_deploy.py
-sleep 10
+sleep 300
 
 
 # Set runtime variables


### PR DESCRIPTION
Allow tenant creation time to complete processes before deploying edges.